### PR TITLE
Fix MultiDatasetTradingEnv dataset selection fairness

### DIFF
--- a/src/gym_trading_env/environments.py
+++ b/src/gym_trading_env/environments.py
@@ -382,7 +382,7 @@ class MultiDatasetTradingEnv(TradingEnv):
         # Find the indexes of the less explored dataset
         potential_dataset_pathes = np.where(self.dataset_nb_uses == self.dataset_nb_uses.min())[0]
         # Pick one of them
-        random_int = np.random.randint(potential_dataset_pathes.size)
+        random_int = np.random.choice(potential_dataset_pathes)
         dataset_idx = potential_dataset_pathes[ random_int ]
         dataset_path = self.dataset_pathes[dataset_idx]
         self.dataset_nb_uses[dataset_idx] += 1 # Update nb use counts


### PR DESCRIPTION
This PR fixes the `MultiDatasetTradingEnv` dataset selection to choose a random dataset among the least used ones instead of always selecting the first one