### PR TITLE
Add agent performance metric to info dict

### DIFF
--- a/src/gym_trading_env/environments.py
+++ b/src/gym_trading_env/environments.py
@@ -389,7 +389,7 @@ class MultiDatasetTradingEnv(TradingEnv):
         potential_dataset_pathes = np.where(self.dataset_nb_uses == self.dataset_nb_uses.min())[0]
         # Pick one of them
         random_int = np.random.choice(potential_dataset_pathes)
-        dataset_idx = potential_dataset_pathes[ random_int ]
+        dataset_idx = potential_dataset_pathes[random_int]
         dataset_path = self.dataset_pathes[dataset_idx]
         self.dataset_nb_uses[dataset_idx] += 1 # Update nb use counts
 


### PR DESCRIPTION
This PR adds an `Agent Performance` metric to the `info` object returned by `step()`, to measure how well the agent is performing compared to the market (whether it outperformed the market or not)