### PR TITLE
Fix multi dataset choice

### DIFF
--- a/src/gym_trading_env/environments.py
+++ b/src/gym_trading_env/environments.py
@@ -388,8 +388,7 @@ class MultiDatasetTradingEnv(TradingEnv):
         # Find the indexes of the less explored dataset
         potential_dataset_pathes = np.where(self.dataset_nb_uses == self.dataset_nb_uses.min())[0]
         # Pick one of them
-        random_int = np.random.choice(potential_dataset_pathes)
-        dataset_idx = potential_dataset_pathes[random_int]
+        dataset_idx = np.random.choice(potential_dataset_pathes)
         dataset_path = self.dataset_pathes[dataset_idx]
         self.dataset_nb_uses[dataset_idx] += 1 # Update nb use counts
 


### PR DESCRIPTION
The previous https://github.com/mzneos/Gym-Trading-Env/pull/1 had a bug because np.random.choice directly returns one of the values from the array, which was already a dataset index.

It let to index out of bounds errors when trying to find that index in the potential_dataset_pathes object, which only contains a subset of all the datasets available

This PR fixes this.